### PR TITLE
Fix: Export route name

### DIFF
--- a/src/TimeSeriesStats.php
+++ b/src/TimeSeriesStats.php
@@ -305,7 +305,7 @@ class TimeSeriesStats
     public static function registerRoutes(
         string $url = '/stats/time-series',
         string $index_name = 'stats.time-series.index',
-        string $export_name = 'stats.time-series.index',
+        string $export_name = 'stats.time-series.export',
         array  $middleware = ['stats.view-time-series']
     )
     {


### PR DESCRIPTION
Having same route name for index and export caused an issue and was first observed when running the `artisan optimize` command. This fixes it.